### PR TITLE
Added serialized spawning limit

### DIFF
--- a/Assets/Scripts/Object/AbstractObject.cs
+++ b/Assets/Scripts/Object/AbstractObject.cs
@@ -20,7 +20,13 @@ namespace Object
         private Vector3 targetPosition;
         private float rotSpeed;
         private Vector3 rotDirection;
+        // Reference to Spawner.cs
+        private Spawner spawner;
 
+
+        public void SetSpawner(Spawner spawnerInstance){
+            spawner = spawnerInstance;
+        }
         public void Start()
         {
             moveSpeed = Random.Range(minMoveSpeed, maxMoveSpeed);
@@ -62,6 +68,11 @@ namespace Object
             LifeManager.lifeCount -= 1;
             AudioSource onDestroySoundInstance = Instantiate(onDestroySound, transform.position, transform.rotation);
             onDestroySoundInstance.Play();
+
+            // Decreases the count for number of objects in scene in spawner class
+            if(spawner != null){
+                spawner.OnObjectDestroyed();
+            }
         }
 
         public void SetMoveSpeed(float value)

--- a/Assets/Scripts/Object/Spawner.cs
+++ b/Assets/Scripts/Object/Spawner.cs
@@ -8,21 +8,31 @@ namespace Object {
 
         private const float xzRange = 10F;
         private const float y = 0F;
+        [SerializeField] private int maxObjectCount = 10;
+        private int currentObjectCount = 0;
 
         public void Start() {
             LifeManager.lifeCount = 3;
         }
         
         public void FixedUpdate() {
-            if (Random.Range(0F, 1F) < 0.01F) {
+            if (currentObjectCount < maxObjectCount && Random.Range(0F, 1F) < 0.01F) {
                 SpawnRandomObject();
+                
             }
         }
 
         private void SpawnRandomObject() {
             AbstractObject[] objects = spawnableManager.GetObjects();
             AbstractObject randomObject = objects[Random.Range(0, objects.Length)];
-            Instantiate(randomObject, Vector.GetRandomPosition(xzRange, y, xzRange), Quaternion.identity);
+            AbstractObject instance = Instantiate(randomObject, Vector.GetRandomPosition(xzRange, y, xzRange), Quaternion.identity);
+
+            instance.SetSpawner(this); // Set the spawner reference in the spawned object
+            currentObjectCount++;
+        }
+
+        public void OnObjectDestroyed(){
+            currentObjectCount--;
         }
     }
 }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
Added serilizable field so we can adjust max spawning in unity.

maxObjectCount and currentObjectCount that incements when objects are spawned and decrements when objects are destroyed. 
A SetSpawner() method is added to AbstractObject to assign the Spawner reference.
The OnDestroy() method in AbstractObject calls OnObjectDestroyed() from the spawner when the object is destroyed.
When spawning an object in Spawner, the reference to Spawner is passed to the new object.